### PR TITLE
Implement glob support for input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add support for globs in arguments. ([#9])
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[#9]: https://github.com/ericcornelissen/wordrow/pull/9

--- a/cmd/wordrow/main.go
+++ b/cmd/wordrow/main.go
@@ -9,7 +9,8 @@ import "github.com/ericcornelissen/wordrow/internal/logger"
 import "github.com/ericcornelissen/wordrow/internal/replacer"
 
 func run(args cli.Arguments) {
-  wordmap, err := dicts.WordMapFrom(args.MapFiles...)
+  mapFiles, err := fs.ResolveGlobs(args.MapFiles...)
+  wordmap, err := dicts.WordMapFrom(mapFiles...)
   if err != nil {
     logger.Error(err)
     return
@@ -19,7 +20,8 @@ func run(args cli.Arguments) {
     wordmap.Invert()
   }
 
-  paths := fs.ResolvePaths(args.InputFiles...)
+  inputFiles, err := fs.ResolveGlobs(args.InputFiles...)
+  paths := fs.ResolvePaths(inputFiles...)
   for i := 0; i < len(paths); i++ {
     filePath := paths[i]
 
@@ -39,7 +41,6 @@ func run(args cli.Arguments) {
     }
   }
 }
-
 
 func main() {
   shouldRun, args := cli.ParseArgs(os.Args)

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/ericcornelissen/wordrow
+
+go 1.12

--- a/internal/fs/paths.go
+++ b/internal/fs/paths.go
@@ -1,10 +1,16 @@
 package fs
 
+import "fmt"
 import "os"
 import "path"
 import "path/filepath"
+import "regexp"
 
 import "github.com/ericcornelissen/wordrow/internal/logger"
+
+
+// Regular expression for glob strings.
+var globExpr = regexp.MustCompile("[\\*\\?\\[\\]]")
 
 
 // Get the (current) working directory.
@@ -18,6 +24,30 @@ func getCwd() string {
   }
 
   return cwd
+}
+
+
+// Resolve any number of globs or file paths into distinct file paths.
+//
+// The error is set if at least one malformed pattern is found. Only the last
+// malformed pattern is detected. The list of paths will contain all paths for
+// valid not-malformed patterns.
+func ResolveGlobs(patterns ...string) (paths []string, rerr error) {
+  for _, pattern := range patterns {
+    if !globExpr.MatchString(pattern) {
+      paths = append(paths, pattern)
+      continue
+    }
+
+    matches, err := filepath.Glob(pattern)
+    if err != nil {
+      rerr = fmt.Errorf("Malformed pattern (%s)", pattern)
+    } else {
+      paths = append(paths, matches...)
+    }
+  }
+
+  return paths, rerr
 }
 
 // Resolve any number of absolute or relative paths to absolute paths only.

--- a/internal/fs/paths_test.go
+++ b/internal/fs/paths_test.go
@@ -13,6 +13,52 @@ func getAnAbsolutePathFor(file string) string {
 }
 
 
+func TestResolveNoGlobs(t *testing.T) {
+  resolvedPaths, err := ResolveGlobs()
+
+  if err != nil {
+    t.Error("Resolving zero globs should not set the error")
+  }
+
+  if len(resolvedPaths) != 0 {
+    t.Error("Resolving zero globs should result in an empty slice")
+  }
+}
+
+func TestResolveGlobsWithoutGlobs(t *testing.T) {
+  path0 := getAnAbsolutePathFor("foo.bar")
+  path1 := "./hello.world"
+  resolvedPaths, err := ResolveGlobs(path0, path1)
+
+  if err != nil {
+    t.Error("Resolving legitimate paths should not set the error")
+  }
+
+  if len(resolvedPaths) != 2 {
+    t.Errorf("Resolving two non-glob paths should return two paths (was %d)", len(resolvedPaths))
+  }
+}
+
+func TestResolveGlobsWithGlobs(t *testing.T) {
+  resolvedPaths, err := ResolveGlobs("./*")
+
+  if err != nil {
+    t.Error("Resolving legitimate globs should not set the error")
+  }
+
+  if len(resolvedPaths) < 1 {
+    t.Errorf("Resolving a glob should return at least one path (was %d)", len(resolvedPaths))
+  }
+}
+
+func TestResolveGlobsWithMalformedPattern(t *testing.T) {
+  _, err := ResolveGlobs("[")
+
+  if err == nil {
+    t.Error("The error should be set for a malformed glob")
+  }
+}
+
 func TestResolveNoPaths(t *testing.T) {
   resolvedPaths := ResolvePaths()
 


### PR DESCRIPTION
Add a new function called `ResolveGlobs` to the `fs` package which can be used to resolve globs into file paths. To do this it is using the `Glob` function of the [filepath package](https://golang.org/pkg/path/filepath/#Glob) of Go.

This function is used to resolve globs of input files and mapping files, as such it closes #8.