### PR TITLE
Create internal errors package

### DIFF
--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,7 +1,6 @@
 package cli
 
-import "errors"
-
+import "github.com/ericcornelissen/wordrow/internal/errors"
 import "github.com/ericcornelissen/wordrow/internal/logger"
 
 

--- a/internal/dicts/dicts.go
+++ b/internal/dicts/dicts.go
@@ -1,9 +1,8 @@
 package dicts
 
-import "errors"
-import "fmt"
 import "strings"
 
+import "github.com/ericcornelissen/wordrow/internal/errors"
 import "github.com/ericcornelissen/wordrow/internal/fs"
 import "github.com/ericcornelissen/wordrow/internal/logger"
 
@@ -62,7 +61,7 @@ func WordMapFrom(files ...string) (WordMap, error) {
 
     err = parseFile(&fileContent, parserFn, &wordmap)
     if err != nil {
-      return wordmap, fmt.Errorf("Error when parsing %s: %s", filePath, err)
+      return wordmap, errors.Newf("Error when parsing %s: %s", filePath, err)
     }
   }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,13 @@
+package errors
+
+import "errors"
+import "fmt"
+
+func New(text string) error {
+  return errors.New(text)
+}
+
+func Newf(text string, args ...interface{}) error {
+  formattedText := fmt.Sprintf(text, args...)
+  return New(formattedText)
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,10 +3,13 @@ package errors
 import "errors"
 import "fmt"
 
+
+// Create a new `error` with a certain error text.
 func New(text string) error {
   return errors.New(text)
 }
 
+// Create a new `error` with a formatted error text.
 func Newf(text string, args ...interface{}) error {
   formattedText := fmt.Sprintf(text, args...)
   return New(formattedText)

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,6 +1,20 @@
 package errors
 
+import "fmt"
 import "testing"
+
+
+func ExampleNew() {
+  err := New("foobar")
+  fmt.Print(err)
+  // Output: foobar
+}
+
+func ExampleNewf() {
+  err := Newf("foo%s", "bar")
+  fmt.Print(err)
+  // Output: foobar
+}
 
 
 func TestNew(t *testing.T) {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import "testing"
+
+
+func TestNew(t *testing.T) {
+  err := New("foobar")
+
+  if err == nil {
+    t.Error("Error should not be nil")
+  }
+
+  if err.Error() != "foobar" {
+    t.Error("not good")
+  }
+}
+
+func TestNewf(t *testing.T) {
+  err := Newf("foo%s", "bar")
+
+  if err == nil {
+    t.Error("Error should not be nil")
+  }
+
+  if err.Error() != "foobar" {
+    t.Error("not good")
+  }
+}

--- a/internal/fs/paths.go
+++ b/internal/fs/paths.go
@@ -1,11 +1,11 @@
 package fs
 
-import "fmt"
 import "os"
 import "path"
 import "path/filepath"
 import "regexp"
 
+import "github.com/ericcornelissen/wordrow/internal/errors"
 import "github.com/ericcornelissen/wordrow/internal/logger"
 
 
@@ -41,7 +41,7 @@ func ResolveGlobs(patterns ...string) (paths []string, rerr error) {
 
     matches, err := filepath.Glob(pattern)
     if err != nil {
-      rerr = fmt.Errorf("Malformed pattern (%s)", pattern)
+      rerr = errors.Newf("Malformed pattern (%s)", pattern)
     } else {
       paths = append(paths, matches...)
     }


### PR DESCRIPTION
Simplify error creation by hiding the standard `errors` package and `fmt`'s `Errorf` function behind an internal `errors` package.

Example 1:

```go
// instead of
import "errors"
errors.New("foobar")

// use
import "internal/errors"
errors.New("foobar")
```

Example 2:

```go
// instead of
import "fmt"
fmt.Errorf("foo%s", "bar")

// use
import "internal/errors"
errors.Newf("foo%s", "bar")
```