### PR TITLE
Handle (and test for) empty values when parsing mapping values

### DIFF
--- a/internal/dicts/csv.go
+++ b/internal/dicts/csv.go
@@ -15,7 +15,7 @@ func parseRow(row string, wordmap *WordMap) error {
 
   fromValue := strings.TrimSpace(rowValues[0])
   toValue := strings.TrimSpace(rowValues[1])
-  if fromValue == "" {
+  if fromValue == "" || toValue == "" {
     return &parseError{"Missing value", row}
   }
 

--- a/internal/dicts/csv.go
+++ b/internal/dicts/csv.go
@@ -13,7 +13,13 @@ func parseRow(row string, wordmap *WordMap) error {
     return &parseError{"Unexpected row format", row}
   }
 
-  wordmap.AddOne(rowValues[0], rowValues[1])
+  fromValue := strings.TrimSpace(rowValues[0])
+  toValue := strings.TrimSpace(rowValues[1])
+  if fromValue == "" {
+    return &parseError{"Missing value", row}
+  }
+
+  wordmap.AddOne(fromValue, toValue)
   return nil
 }
 

--- a/internal/dicts/csv_test.go
+++ b/internal/dicts/csv_test.go
@@ -63,27 +63,39 @@ func TestCsvMultipleRows(t *testing.T) {
   }
 }
 
-func TestCsvEmptyToValue(t *testing.T) {
-  csv := `cat,`
-  wordmap, err := parseCsvFile(&csv)
+func TestCsvEmptyColumnValues(t *testing.T) {
+  t.Run("Empty from value", func(t *testing.T) {
+    csv := `,bar`
 
-  if err != nil {
-    t.Fatalf("Error should be nil for this test (Error: %s)", err)
-  }
+    _, err := parseCsvFile(&csv)
 
-  if wordmap.Size() != 1 {
-    t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
-  }
+    if err == nil {
+      t.Errorf("Error should be set if the from value is empty")
+    }
+  })
+  t.Run("Empty to value", func(t *testing.T) {
+    csv := `foo,`
 
-  actual, expected := wordmap.GetFrom(0), "cat"
-  if actual != expected {
-    t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
-  }
+    wordmap, err := parseCsvFile(&csv)
 
-  actual, expected = wordmap.GetTo(0), ""
-  if actual != expected {
-    t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
-  }
+    if err != nil {
+      t.Fatalf("Error should be nil for this test (Error: %s)", err)
+    }
+
+    if wordmap.Size() != 1 {
+      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
+    }
+
+    actual, expected := wordmap.GetFrom(0), "foo"
+    if actual != expected {
+      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
+    }
+
+    actual, expected = wordmap.GetTo(0), ""
+    if actual != expected {
+      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
+    }
+  })
 }
 
 func TestCsvIgnoreEmptyLines(t *testing.T) {

--- a/internal/dicts/csv_test.go
+++ b/internal/dicts/csv_test.go
@@ -76,24 +76,10 @@ func TestCsvEmptyColumnValues(t *testing.T) {
   t.Run("Empty to value", func(t *testing.T) {
     csv := `foo,`
 
-    wordmap, err := parseCsvFile(&csv)
+    _, err := parseCsvFile(&csv)
 
-    if err != nil {
-      t.Fatalf("Error should be nil for this test (Error: %s)", err)
-    }
-
-    if wordmap.Size() != 1 {
-      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
-    }
-
-    actual, expected := wordmap.GetFrom(0), "foo"
-    if actual != expected {
-      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
-    }
-
-    actual, expected = wordmap.GetTo(0), ""
-    if actual != expected {
-      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
+    if err == nil {
+      t.Errorf("Error should be set if the to value is empty")
     }
   })
 }

--- a/internal/dicts/markdown.go
+++ b/internal/dicts/markdown.go
@@ -25,10 +25,13 @@ func parseTableRow(row string) ([]string, error) {
     return nil, &parseError{"Unexpected table row format", row}
   }
 
-  return []string{
-    strings.TrimSpace(rowValues[1]),
-    strings.TrimSpace(rowValues[2]),
-  }, nil
+  fromValue := strings.TrimSpace(rowValues[1])
+  toValue := strings.TrimSpace(rowValues[2])
+  if fromValue == "" {
+    return nil, &parseError{"Missing value", row}
+  }
+
+  return []string{fromValue, toValue}, nil
 }
 
 // Parse the header of a MarkDown table.

--- a/internal/dicts/markdown.go
+++ b/internal/dicts/markdown.go
@@ -27,7 +27,7 @@ func parseTableRow(row string) ([]string, error) {
 
   fromValue := strings.TrimSpace(rowValues[1])
   toValue := strings.TrimSpace(rowValues[2])
-  if fromValue == "" {
+  if fromValue == "" || toValue == "" {
     return nil, &parseError{"Missing value", row}
   }
 

--- a/internal/dicts/markdown_test.go
+++ b/internal/dicts/markdown_test.go
@@ -121,6 +121,49 @@ func TestMarkDownTwoTables(t *testing.T) {
   }
 }
 
+func TestMarkDownEmptyColumnValues(t *testing.T) {
+  t.Run("Empty from value", func(t *testing.T) {
+    markdown := `
+      | from | to  |
+      | ---- | --- |
+      |      | bar |
+    `
+
+    _, err := parseMarkDownFile(&markdown)
+
+    if err == nil {
+      t.Errorf("Error should be set if the from value is empty")
+    }
+  })
+  t.Run("Empty to value", func(t *testing.T) {
+    markdown := `
+      | from | to |
+      | ---- | -- |
+      | foo  |    |
+    `
+
+    wordmap, err := parseMarkDownFile(&markdown)
+
+    if err != nil {
+      t.Fatalf("Error should be nil for this test (Error: %s)", err)
+    }
+
+    if wordmap.Size() != 1 {
+      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
+    }
+
+    actual, expected := wordmap.GetFrom(0), "foo"
+    if actual != expected {
+      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
+    }
+
+    actual, expected = wordmap.GetTo(0), ""
+    if actual != expected {
+      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
+    }
+  })
+}
+
 func TestMarkDownIncorrectHeader(t *testing.T) {
   markdown := `
     | foo |

--- a/internal/dicts/markdown_test.go
+++ b/internal/dicts/markdown_test.go
@@ -142,24 +142,10 @@ func TestMarkDownEmptyColumnValues(t *testing.T) {
       | foo  |    |
     `
 
-    wordmap, err := parseMarkDownFile(&markdown)
+    _, err := parseMarkDownFile(&markdown)
 
-    if err != nil {
-      t.Fatalf("Error should be nil for this test (Error: %s)", err)
-    }
-
-    if wordmap.Size() != 1 {
-      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
-    }
-
-    actual, expected := wordmap.GetFrom(0), "foo"
-    if actual != expected {
-      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
-    }
-
-    actual, expected = wordmap.GetTo(0), ""
-    if actual != expected {
-      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
+    if err == nil {
+      t.Errorf("Error should be set if the to value is empty")
     }
   })
 }

--- a/internal/dicts/wordmap.go
+++ b/internal/dicts/wordmap.go
@@ -37,7 +37,7 @@ func (m *WordMap) AddFrom(other WordMap) {
 func (m *WordMap) AddOne(from, to string) {
   fromValue := strings.TrimSpace(strings.ToLower(from))
   toValue := strings.TrimSpace(strings.ToLower(to))
-  if fromValue == "" {
+  if fromValue == "" || toValue == "" {
     panic(1)
   }
 

--- a/internal/dicts/wordmap.go
+++ b/internal/dicts/wordmap.go
@@ -32,9 +32,17 @@ func (m *WordMap) AddFrom(other WordMap) {
 }
 
 // Add a single mapping from one word to another to the WordMap.
+//
+// This function panics if an empty string is provided as first argument.
 func (m *WordMap) AddOne(from, to string) {
-  m.from = append(m.from, strings.TrimSpace(strings.ToLower(from)))
-  m.to = append(m.to, strings.TrimSpace(strings.ToLower(to)))
+  fromValue := strings.TrimSpace(strings.ToLower(from))
+  toValue := strings.TrimSpace(strings.ToLower(to))
+  if fromValue == "" {
+    panic(1)
+  }
+
+  m.from = append(m.from, fromValue)
+  m.to = append(m.to, toValue)
 }
 
 // Check whether the WordMap contains a mapping from a certain string. Note that

--- a/internal/dicts/wordmap.go
+++ b/internal/dicts/wordmap.go
@@ -33,7 +33,8 @@ func (m *WordMap) AddFrom(other WordMap) {
 
 // Add a single mapping from one word to another to the WordMap.
 //
-// This function panics if an empty string is provided as first argument.
+// This function panics if an empty string is provided as first or second
+// argument.
 func (m *WordMap) AddOne(from, to string) {
   fromValue := strings.TrimSpace(strings.ToLower(from))
   toValue := strings.TrimSpace(strings.ToLower(to))

--- a/internal/dicts/wordmap_test.go
+++ b/internal/dicts/wordmap_test.go
@@ -44,21 +44,14 @@ func TestWordMapEmptyValues(t *testing.T) {
     t.Error("AddOne should have panicked but did not")
   })
   t.Run("Empty to value", func(t *testing.T) {
+    defer func() {
+      if r := recover(); r == nil {
+        t.Error("AddOne did not need recovery, but should have")
+      }
+    }()
+
     wordmap.AddOne("foo", "")
-
-    if wordmap.Size() != 1 {
-      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
-    }
-
-    actual, expected := wordmap.GetFrom(0), "foo"
-    if actual != expected {
-      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
-    }
-
-    actual, expected = wordmap.GetTo(0), ""
-    if actual != expected {
-      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
-    }
+    t.Error("AddOne should have panicked but did not")
   })
 }
 

--- a/internal/dicts/wordmap_test.go
+++ b/internal/dicts/wordmap_test.go
@@ -30,6 +30,38 @@ func TestWordMapAddOne(t *testing.T)  {
   }
 }
 
+func TestWordMapEmptyValues(t *testing.T) {
+  var wordmap WordMap
+
+  t.Run("Empty from value", func(t *testing.T) {
+    defer func() {
+      if r := recover(); r == nil {
+        t.Error("AddOne did not need recovery, but should have")
+      }
+    }()
+
+    wordmap.AddOne("", "bar")
+    t.Error("AddOne should have panicked but did not")
+  })
+  t.Run("Empty to value", func(t *testing.T) {
+    wordmap.AddOne("foo", "")
+
+    if wordmap.Size() != 1 {
+      t.Fatalf("The WordMap size should be 1 (was %d)", wordmap.Size())
+    }
+
+    actual, expected := wordmap.GetFrom(0), "foo"
+    if actual != expected {
+      t.Errorf("Incorrect from-value at index 0 (actual %s)", actual)
+    }
+
+    actual, expected = wordmap.GetTo(0), ""
+    if actual != expected {
+      t.Errorf("Incorrect to-value at index 0 (actual %s)", actual)
+    }
+  })
+}
+
 func TestWordMapAddFrom(t *testing.T)  {
   var wordmapA, wordmapB WordMap
 


### PR DESCRIPTION
This adds testing for how (existing) parsers of mapping files handle empty values and updates them to do so correctly.

In addition it adds a guarantee for other packages that this is not the case by panicking in the `WordMap` struct if an empty "from" value is added.