### PR TITLE
Make mapping file formats case insenstive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 
 - Add option to explicitly state map file format. ([#46])
 - Add support for more extensions as MarkDown map file. ([#50])
+- Allow file extension of map files to be upper or mixed case. ([#55])
 
 ### Bug Fixes
 
@@ -73,3 +74,4 @@ Versioning].
 [#42]: https://github.com/ericcornelissen/wordrow/pull/42
 [#46]: https://github.com/ericcornelissen/wordrow/pull/46
 [#50]: https://github.com/ericcornelissen/wordrow/pull/50
+[#55]: https://github.com/ericcornelissen/wordrow/pull/55

--- a/cmd/wordrow/wordmap.go
+++ b/cmd/wordrow/wordmap.go
@@ -9,7 +9,7 @@ import "github.com/ericcornelissen/wordrow/internal/wordmaps"
 
 // Parse a --map-file argument into its component parts.
 func parseWordMapArgument(argument string) (path string, format string) {
-	fileExtension := fs.GetExt(path)
+	fileExtension := fs.GetExt(argument)
 
 	tmp := strings.Split(fileExtension, ":")
 	if len(tmp) > 1 {

--- a/internal/wordmaps/parse.go
+++ b/internal/wordmaps/parse.go
@@ -6,10 +6,10 @@ import "github.com/ericcornelissen/wordrow/internal/errors"
 
 var (
 	// Regular expression of names considered as MarkDown format.
-	md = regexp.MustCompile(`\.(md(te?xt)?|markdown|mdown|mkdown|mkd|mdwn|mkdn)`)
+	md = regexp.MustCompile(`(?i)\.(md(te?xt)?|markdown|mdown|mkdown|mkd|mdwn|mkdn)`)
 
 	// Regular expression of names considered as CSV format.
-	csv = regexp.MustCompile(`csv`)
+	csv = regexp.MustCompile(`(?i)\.csv`)
 )
 
 // A parse function is a function that takes the contents of a file as a string

--- a/internal/wordmaps/parse_test.go
+++ b/internal/wordmaps/parse_test.go
@@ -27,6 +27,10 @@ func TestGetParserForMarkDownFile(t *testing.T) {
 		parseFn, err := getParserForFormat(".md")
 		check(parseFn, err)
 	})
+	t.Run(".MD", func(t *testing.T) {
+		parseFn, err := getParserForFormat(".MD")
+		check(parseFn, err)
+	})
 	t.Run(".mdown", func(t *testing.T) {
 		parseFn, err := getParserForFormat(".mdown")
 		check(parseFn, err)
@@ -54,16 +58,25 @@ func TestGetParserForMarkDownFile(t *testing.T) {
 }
 
 func TestGetParserForCSVFile(t *testing.T) {
-	parseFn, err := getParserForFormat(".csv")
+	check := func(parseFn parseFunction, err error) {
+		if err != nil {
+			t.Fatalf("The error should be nil for this test (Error: %s)", err)
+		}
 
-	if err != nil {
-		t.Fatalf("The error should be nil for this test (Error: %s)", err)
+		actual, expected := reflect.ValueOf(parseFn), reflect.ValueOf(parseCsvFile)
+		if actual.Pointer() != expected.Pointer() {
+			t.Error("The parser function should be the CSV parse function")
+		}
 	}
 
-	actual, expected := reflect.ValueOf(parseFn), reflect.ValueOf(parseCsvFile)
-	if actual.Pointer() != expected.Pointer() {
-		t.Error("The parser function should be the CSV parse function")
-	}
+	t.Run(".csv", func(t *testing.T) {
+		parseFn, err := getParserForFormat(".csv")
+		check(parseFn, err)
+	})
+	t.Run(".CSV", func(t *testing.T) {
+		parseFn, err := getParserForFormat(".CSV")
+		check(parseFn, err)
+	})
 }
 
 func TestParseFileNoParser(t *testing.T) {


### PR DESCRIPTION
Closes #53

In addition, this fixes a small issue in a new feature where mapping files where no longer being read properly due to using the wrong variable name (see 2f14a6525c80badf9f5be933d7b52787bac3c0d2)