### PR TITLE
Update help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning].
 ### Documentation
 
 - Update use of outdated CLI argument name. ([#67])
+- Update use of outdated term in CLI help message. ([#71])
 
 ## [0.4.0-beta] - 2020-05-27
 
@@ -92,3 +93,4 @@ Versioning].
 [#61]: https://github.com/ericcornelissen/wordrow/pull/61
 [#65]: https://github.com/ericcornelissen/wordrow/pull/65
 [#67]: https://github.com/ericcornelissen/wordrow/pull/67
+[#71]: https://github.com/ericcornelissen/wordrow/pull/71

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -72,21 +72,21 @@ func printSectionTitle(title string) {
 func printOptions() {
 	printSectionTitle("Flags")
 	printOption(helpFlag, `Output this help message.`)
-	printOption(versionFlag, `Output the version number of wordrow.`)
+	printOption(versionFlag, `Output the version number of the program.`)
 	printOption(dryRunFlag, `Don't make any changes to the input files.`)
 	printOption(invertFlag, `Invert all specified mappings.`)
-	printOption(silentFlag, `Don't output informative logging.`)
-	printOption(verboseFlag, `Output debug logging.`)
+	printOption(silentFlag, `Disable informative logging.`)
+	printOption(verboseFlag, `Enabled debug logging.`)
 
 	printSectionTitle("Options")
 	printOption(configOption, `Specify a configuration file.`)
 	printOption(mapfileOption, `
-		Specify a dictionary file. To use multiple dictionary files you can use this
-		option multiple times.
+		Specify a file with a mapping. To use multiple mapping files you can use
+		this option multiple times.
 	`)
 	printOption(mappingOption, `
-		Specify a single mapping. Use a comma to separate the words of the mapping.
-		If spaces are required use quotation marks. This option can be used multiple
+		Specify a mapping. Use a comma to separate the words of the mapping. If
+		spaces are required use quotation marks. This option can be used multiple
 		times.
 	`)
 }


### PR DESCRIPTION
- Replace _"wordrow"_ with _"the program"_ in `--version` description.
- Use _"enable"_ and _"disable"_ in `--silent` and `--verbose` descriptions.
- Replace outdated usage of word _"dictionary"_  in `--map-file` description.
- Update wording of `--map` description.