### PR TITLE
Fix double newline in some log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning].
 - Add functionality to map many words to one word. ([#65])
 - Add option to specify multiple flags at once. ([#72])
 
+### Bug Fixes
+
+- Remove double newline in program logs. ([#78])
+
 ### Documentation
 
 - Update use of outdated CLI argument name. ([#67])
@@ -96,3 +100,4 @@ Versioning].
 [#67]: https://github.com/ericcornelissen/wordrow/pull/67
 [#71]: https://github.com/ericcornelissen/wordrow/pull/71
 [#72]: https://github.com/ericcornelissen/wordrow/pull/72
+[#78]: https://github.com/ericcornelissen/wordrow/pull/78

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -54,7 +54,7 @@ func Debug(msgs ...interface{}) {
 // Debugf formats and prints a message as a debug message.
 func Debugf(msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	Debug(formattedMsg + "\n")
+	Debug(formattedMsg)
 }
 
 // Error prints messages as an error message.
@@ -66,7 +66,7 @@ func Error(msgs ...interface{}) {
 // Errorf formats and prints a message as an error message.
 func Errorf(msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	Error(formattedMsg + "\n")
+	Error(formattedMsg)
 }
 
 // Fatal prints messages as a fatal message.
@@ -78,7 +78,7 @@ func Fatal(msgs ...interface{}) {
 // Fatalf formats and prints a message as a fatal message.
 func Fatalf(msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	Fatal(formattedMsg + "\n")
+	Fatal(formattedMsg)
 }
 
 // Info prints messages as an info message.
@@ -90,7 +90,7 @@ func Info(msgs ...interface{}) {
 // Infof formats and prints a message as an info message.
 func Infof(msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	Info(formattedMsg + "\n")
+	Info(formattedMsg)
 }
 
 // Println prints messages.
@@ -112,5 +112,5 @@ func Warning(msgs ...interface{}) {
 // Warningf formats and prints a message as a warning message.
 func Warningf(msg string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(msg, args...)
-	Warning(formattedMsg + "\n")
+	Warning(formattedMsg)
 }


### PR DESCRIPTION
This fixes a small annoyance where logging would contain an extra newline between some loglines. This was due to the fact that all `Logf` functions manually added `"\n"` an subsequently be logged with another newline.

* * *

Before:

```
$ ./wordrow -iv --map a,b --map c,d ./input.txt
[Debug] Processing CLI specified map files...
[Debug] Processing CLI specified mappings...
[Debug] Processing CLI specified mapping: 'a,b'

[Debug] Processing CLI specified mapping: 'c,d'

[Debug] Processing '/usr/eric/input.txt' as input file
```

After: 

```
$ ./wordrow -iv --map a,b --map c,d ./input.txt
[Debug] Processing CLI specified map files...
[Debug] Processing CLI specified mappings...
[Debug] Processing CLI specified mapping: 'a,b'
[Debug] Processing CLI specified mapping: 'c,d'
[Debug] Processing '/usr/eric/input.txt' as input file
```