### PR TITLE
Mitigate gosec G304 error in fs.OpenFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versioning].
 - Update use of outdated CLI argument name. ([#67])
 - Update use of outdated term in CLI help message. ([#71])
 
+### Security
+
+- Clean provided file paths before opening ([#99])
+
 ## [0.4.0-beta] - 2020-05-27
 
 ### Features
@@ -101,3 +105,4 @@ Versioning].
 [#71]: https://github.com/ericcornelissen/wordrow/pull/71
 [#72]: https://github.com/ericcornelissen/wordrow/pull/72
 [#78]: https://github.com/ericcornelissen/wordrow/pull/78
+[#99]: https://github.com/ericcornelissen/wordrow/pull/99

--- a/internal/fs/open.go
+++ b/internal/fs/open.go
@@ -1,6 +1,9 @@
 package fs
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // The default mode used by OpenFile.
 const mode = 0600
@@ -8,7 +11,8 @@ const mode = 0600
 // OpenFile opens a File handle to interact with the file specified by
 // `filePath`.
 func OpenFile(filePath string, flag Flag) (file *File, err error) {
-	osFile, err := os.OpenFile(filePath, flagToFlag(flag), mode)
+	cleanFilePath := filepath.Clean(filePath)
+	osFile, err := os.OpenFile(cleanFilePath, flagToFlag(flag), mode)
 	return &File{
 		handle: osFile,
 		path:   filePath,

--- a/internal/fs/open.go
+++ b/internal/fs/open.go
@@ -11,8 +11,7 @@ const mode = 0600
 // OpenFile opens a File handle to interact with the file specified by
 // `filePath`.
 func OpenFile(filePath string, flag Flag) (file *File, err error) {
-	cleanFilePath := filepath.Clean(filePath)
-	osFile, err := os.OpenFile(cleanFilePath, flagToFlag(flag), mode)
+	osFile, err := os.OpenFile(filepath.Clean(filePath), flagToFlag(flag), mode)
 	return &File{
 		handle: osFile,
 		path:   filePath,


### PR DESCRIPTION
As per the (current) gosec docs [1] rule G304 warns about:

> File path provided as taint input

Following the gosec guidelines [2] this Pull Request adds a call to `filePath.Clean` before opening the specified file.

[1]: https://github.com/securego/gosec/tree/6bcd89aa6b1cc8a448f99d51886ac29703eb1804#available-rules
[2]: https://securego.io/docs/rules/g304.html