### PR TITLE
Change log from Error to Fatal when arguments cannot be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 ### Bug Fixes
 
 - Fix bug preventing the usage of map files without file extension. ([#101])
+- Fix logs of incorrect level being logged. ([#107], [#108])
 
 ## [0.5.0-beta] - 2020-07-24
 
@@ -118,3 +119,5 @@ Versioning].
 [#98]: https://github.com/ericcornelissen/wordrow/pull/98
 [#99]: https://github.com/ericcornelissen/wordrow/pull/99
 [#101]: https://github.com/ericcornelissen/wordrow/pull/101
+[#107]: https://github.com/ericcornelissen/wordrow/pull/107
+[#108]: https://github.com/ericcornelissen/wordrow/pull/108

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -154,7 +154,7 @@ func ParseArgs(args []string) (run bool, arguments Arguments) {
 
 	arguments, err := doParseProgramArguments(args[1:])
 	if err != nil {
-		logger.Error(err)
+		logger.Fatalf("An error occurred while parsing arguments: %s", err)
 		return false, arguments
 	}
 


### PR DESCRIPTION
Contributes to #35. (also slightly improves on the logged text)