### PR TITLE
Run Security Workflow on (some) pushes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,10 @@
 name: Security
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'sec**'
 
 jobs:
   gosec:


### PR DESCRIPTION
Add support for the GitHub Actions Security Workflow to run on pushes (instead of only on Pull Requests). However, the Workflow will not be ran for pushes to all branches. Most importantly, it runs the Security Workflow on the `master` branch. Additionally, it also runs on any branch whose name starts with `"sec"` (short for "security") as that is an indication that the branch is concerned with security and therefore would be interested in (automated) security feedback.