### PR TITLE
Update Actions Workflow to run all tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,8 @@ jobs:
       run: make build
 
     # Testing
+    - name: Test (all)
+      run: make test
     - name: Test (with coverage)
       run: make coverage
     - name: Publish code coverage


### PR DESCRIPTION
[The build](https://github.com/ericcornelissen/wordrow/runs/935166930) for commit 1c5591303cedc096d37839be7dee0162d3693f56 should have failed as a new test against an existing bug was introduced (without a bug fix). However, the build did not fail because the tests for `cmd/wordrow` are currently not run in the CI :fearful: :sweat_smile:

This Pull Request updates the Workflow file that runs tests to make sure `make test` is run (running all test) in addition to `make coverage` (running only the tests whose coverage is of interest, which is potentially not all tests).