### PR TITLE
Update CLI help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Versioning].
 - Fix bug preventing the usage of map files without file extension. ([#101])
 - Fix logs of incorrect level being logged. ([#107], [#108])
 - Fix crash due to empty values in the `--map` option. ([#110])
-- Fix mistakes in the program help message. ([#114])
+- Fix mistakes in the program help message. ([#114], [#115])
 
 ### Miscellaneous
 
@@ -134,3 +134,4 @@ Versioning].
 [#108]: https://github.com/ericcornelissen/wordrow/pull/108
 [#110]: https://github.com/ericcornelissen/wordrow/pull/110
 [#114]: https://github.com/ericcornelissen/wordrow/pull/114
+[#115]: https://github.com/ericcornelissen/wordrow/pull/115

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -95,11 +95,16 @@ func printInterface() {
 	base := "Usage: wordrow"
 	indentation := asWhitespace(base)
 
-	fmt.Printf("%s [%s] [%s] [%s]\n",
+	fmt.Printf("%s [%s] [%s]\n",
 		base,
 		helpFlag.name,
 		versionFlag.name,
+	)
+	fmt.Printf("%s [%s] [%s | %s]\n",
+		indentation,
 		dryRunFlag.name,
+		invertFlag.alias,
+		invertFlag.name,
 	)
 	fmt.Printf("%s [%s | %s] [%s | %s]\n",
 		indentation,


### PR DESCRIPTION
Following up on #114, this also adds the `--invert`/`-i` flag to the program interface in the help message.