### PR TITLE
Update CLI help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Versioning].
 - Fix bug preventing the usage of map files without file extension. ([#101])
 - Fix logs of incorrect level being logged. ([#107], [#108])
 - Fix crash due to empty values in the `--map` option. ([#110])
-- Fix mistakes in the program help message. ([#114], [#115])
+- Fix mistakes in the program help message. ([#114], [#115], [#116])
 
 ### Miscellaneous
 
@@ -135,3 +135,4 @@ Versioning].
 [#110]: https://github.com/ericcornelissen/wordrow/pull/110
 [#114]: https://github.com/ericcornelissen/wordrow/pull/114
 [#115]: https://github.com/ericcornelissen/wordrow/pull/115
+[#116]: https://github.com/ericcornelissen/wordrow/pull/116

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -118,7 +118,7 @@ func printInterface() {
 		mapfileOption.alias,
 		mapfileOption.name,
 	)
-	fmt.Printf("%s [%s | %s <file>]\n",
+	fmt.Printf("%s [%s | %s <mapping>]\n",
 		indentation,
 		mappingOption.alias,
 		mappingOption.name,


### PR DESCRIPTION
Following up on #114 and #115, this fixes the text of the `--map`/`-m` option in the program interface in the help message.