### PR TITLE
Add `make init` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ of this project. Note that the table is (intentionally) incomplete.
 | Command          | Description                                          |
 | ---------------- | ---------------------------------------------------- |
 | `make`           | Compile a binary called `wordrow` for the current OS |
+| `make init`      | Initialize the development environment               |
 | `make install`   | Install all dependencies for the project             |
 | `make test`      | Run all test suites for the project                  |
 | `make coverage`  | Run all test suites and show the coverage results    |
@@ -116,32 +117,9 @@ of this project. Note that the table is (intentionally) incomplete.
 ### Git Hooks
 
 We recommend [setting up a Git hook](https://githooks.com) on commits or pushes
-to make sure your changes don't include any accidental mistakes. You can use the
-following shell script as a template.
-
-```shell
-#!/bin/sh
-
-set -e
-
-# Stash unstaged changes
-git stash -q --keep-index
-
-# See if the project can be build and all tests pass.
-make
-make test
-
-# Format the codebase and include (relevant) formatting changes in the commit.
-make format
-git update-index --again
-
-# Check other formatting things. You can use `make lint-go` if you don't have
-# NodeJS on your system.
-make lint
-
-# Restore unstaged changes
-git stash pop -q
-```
+to make sure your changes don't include any accidental mistakes. If you run
+`make hooks` (or `make init`) the recommended hooks will be installed for you.
+The source of these hooks can be found in [the `scripts/` directory](/scripts).
 
 ### Docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN apk add --no-cache \
 # Set up
 WORKDIR /go/src/wordrow
 COPY Makefile ./
-RUN make install
+COPY scripts/ ./scripts
+COPY .git/ ./.git
+RUN make init
 
 # Remove build-only tools
 RUN apk del \

--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,20 @@ default: build
 init: hooks install
 
 hooks:
-	@echo "SETTING UP GIT HOOKS"
+	@echo SETTING UP GIT HOOKS...
 	@cp ./scripts/pre-commit.sh ./.git/hooks/pre-commit
 
 install: install-deps install-dev-deps
 
 install-deps:
-	@echo "INSTALLLING DEPENDENCIES"
+	@echo INSTALLING DEPENDENCIES...
 	$(go_install) github.com/yargevad/filepathx
 	$(go_install) github.com/ericcornelissen/stringsx
 
 install-dev-deps:
-	@echo "INSTALLLING DEVELOPMENT TOOLS"
+	@echo INSTALLING DEVELOPMENT TOOLS...
 	$(go_install) golang.org/x/tools/cmd/goimports
-	@echo "INSTALLLING STATIC ANALYSIS TOOLS"
+	@echo INSTALLING STATIC ANALYSIS TOOLS...
 	$(go_install) 4d63.com/gochecknoinits
 	$(go_install) gitlab.com/opennota/check/cmd/aligncheck
 	$(go_install) gitlab.com/opennota/check/cmd/structcheck
@@ -50,7 +50,7 @@ install-dev-deps:
 	$(go_install) golang.org/x/lint/golint
 	$(go_install) honnef.co/go/tools/cmd/staticcheck
 	$(go_install) mvdan.cc/unparam
-	@echo "INSTALLLING MANUAL ANALYSIS TOOLS"
+	@echo INSTALLING MANUAL ANALYSIS TOOLS...
 	$(go_install) github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
 
 build:
@@ -87,7 +87,7 @@ benchmark:
 	go test $(test_root) -bench=. -run=XXX
 
 analysis:
-	@echo "VETTING..."
+	@echo VETTING...
 	@go vet ./...
 	@aligncheck ./...
 	@dogsled -n 1 -set_exit_status ./...
@@ -103,10 +103,10 @@ analysis:
 	@unparam -exported -tests ./...
 	@varcheck -e ./...
 
-	@echo "VERIFYING ERRORS ARE CHECKED..."
+	@echo VERIFYING ERRORS ARE CHECKED...
 	@errcheck -asserts -blank -ignoretests -exclude .errcheckrc.txt ./...
 
-	@echo "CHECKING FOR DEAD CODE..."
+	@echo CHECKING FOR DEAD CODE...
 	@ineffassign ./*
 	@deadcode ./internal/*
 	@deadcode ./cmd/*

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ go_install:=GO111MODULE=on go get -u
 
 default: build
 
+init: hooks install
+
 hooks:
 	@echo "SETTING UP GIT HOOKS"
 	@cp ./scripts/pre-commit.sh ./.git/hooks/pre-commit
@@ -132,4 +134,4 @@ clean:
 	rm `find ./ -name '_fuzz'` -rf
 	rm `find ./ -name '*-fuzz.zip'` -rf
 
-.PHONY: default hooks install build clean format lint analysis test fuzz
+.PHONY: default init hooks install build clean format lint analysis test fuzz

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ go_install:=GO111MODULE=on go get -u
 
 default: build
 
+hooks:
+	@echo "SETTING UP GIT HOOKS"
+	@cp ./scripts/pre-commit.sh ./.git/hooks/pre-commit
+
 install: install-deps install-dev-deps
 
 install-deps:
@@ -128,4 +132,4 @@ clean:
 	rm `find ./ -name '_fuzz'` -rf
 	rm `find ./ -name '*-fuzz.zip'` -rf
 
-.PHONY: default install build clean format lint analysis test fuzz
+.PHONY: default hooks install build clean format lint analysis test fuzz

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+# Stash unstaged changes
+git stash -q -u --keep-index
+
+# See if the project can be build and tests pass.
+make
+make test
+
+# Format the code base and include (relevant) formatting changes in the commit.
+make format
+git update-index --again
+
+# Check other formatting things. You can use `make lint-go` if you don't have
+# NodeJS on your system.
+make lint
+
+# Restore unstaged changes
+git stash pop -q


### PR DESCRIPTION
Add a new Makefile command (`make init`) that can be used to initialize the development environment. This command relies on the `make install` command and the (new) `make hooks` command. The `make hooks` command will install recommended git hooks (found in the `scripts/` directory) into the local repository.

The Contributing Guidelines and Dockerfile are updated accordingly.