### PR TITLE
Allow for prefix notation in inline mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning].
 - Run on STDIN. ([#119])
 - Process input files in parallel. ([#132])
 
+### Bug Fixes
+
+- Allow for prefix notation in inline mappings. ([#136])
+
 ### Miscellaneous
 
 - Log when a mapping is overwritten. ([#134])
@@ -158,3 +162,4 @@ Versioning].
 [#119]: https://github.com/ericcornelissen/wordrow/pull/119
 [#132]: https://github.com/ericcornelissen/wordrow/pull/132
 [#134]: https://github.com/ericcornelissen/wordrow/pull/134
+[#136]: https://github.com/ericcornelissen/wordrow/pull/136

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -106,11 +106,7 @@ func doParseOneArgument(
 	context argContext,
 	arguments *Arguments,
 ) (newContext argContext, err error) {
-	if stringsx.HasPrefix(arg, "-") {
-		if context != contextDefault {
-			return context, errors.Newf("Missing value for %s option", context)
-		}
-
+	if context == contextDefault && stringsx.HasPrefix(arg, "-") {
 		newContext, err = doParseOneOption(arg, arguments)
 	} else {
 		context.parseValue(arg, arguments)

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -402,6 +402,66 @@ func TestMappingOption(t *testing.T) {
 			t.Errorf("First mapping was incorrect (was '%s')", arguments.Mappings[0])
 		}
 	})
+	t.Run("prefix notation", func(t *testing.T) {
+		mapping := "-bar,-baz"
+
+		args := createArgs(mappingOption.name, mapping, "foo.bar")
+		run, arguments := ParseArgs(args)
+
+		if run != true {
+			t.Fatal("The first return value should be true for this test")
+		}
+
+		testDefaultsExcept(t, &arguments, "mappings")
+
+		if len(arguments.Mappings) != 1 {
+			t.Fatalf("The Mappings list must have length 1 (was %d)", len(arguments.Mappings))
+		}
+
+		if arguments.Mappings[0] != mapping {
+			t.Errorf("First mapping was incorrect (was '%s')", arguments.Mappings[0])
+		}
+	})
+	t.Run("suffix notation", func(t *testing.T) {
+		mapping := "foo-,zoo-"
+
+		args := createArgs(mappingOption.name, mapping, "foo.bar")
+		run, arguments := ParseArgs(args)
+
+		if run != true {
+			t.Fatal("The first return value should be true for this test")
+		}
+
+		testDefaultsExcept(t, &arguments, "mappings")
+
+		if len(arguments.Mappings) != 1 {
+			t.Fatalf("The Mappings list must have length 1 (was %d)", len(arguments.Mappings))
+		}
+
+		if arguments.Mappings[0] != mapping {
+			t.Errorf("First mapping was incorrect (was '%s')", arguments.Mappings[0])
+		}
+	})
+	t.Run("prefix & suffix notation", func(t *testing.T) {
+		mapping := "-bloody-,-freaking-"
+
+		args := createArgs(mappingOption.name, mapping, "foo.bar")
+		run, arguments := ParseArgs(args)
+
+		if run != true {
+			t.Fatal("The first return value should be true for this test")
+		}
+
+		testDefaultsExcept(t, &arguments, "mappings")
+
+		if len(arguments.Mappings) != 1 {
+			t.Fatalf("The Mappings list must have length 1 (was %d)", len(arguments.Mappings))
+		}
+
+		if arguments.Mappings[0] != mapping {
+			t.Errorf("First mapping was incorrect (was '%s')", arguments.Mappings[0])
+		}
+	})
 }
 
 func TestMappingOptionIncorrect(t *testing.T) {

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -402,6 +402,9 @@ func TestMappingOption(t *testing.T) {
 			t.Errorf("First mapping was incorrect (was '%s')", arguments.Mappings[0])
 		}
 	})
+}
+
+func TestMappingOptionWithAffixNotation(t *testing.T) {
 	t.Run("prefix notation", func(t *testing.T) {
 		mapping := "-bar,-baz"
 


### PR DESCRIPTION
Closes #84, fixing the bug described there by allowing CLI argument values to start with a hyphen.
