### PR TITLE
Use non-zero exit codes for errors and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 
 - Run on STDIN. ([#119])
 - Process input files in parallel. ([#132])
+- Exit with a non-zero code on errors. ([#139])
 
 ### Bug Fixes
 
@@ -163,3 +164,4 @@ Versioning].
 [#132]: https://github.com/ericcornelissen/wordrow/pull/132
 [#134]: https://github.com/ericcornelissen/wordrow/pull/134
 [#136]: https://github.com/ericcornelissen/wordrow/pull/136
+[#139]: https://github.com/ericcornelissen/wordrow/pull/139

--- a/cmd/wordrow/constants.go
+++ b/cmd/wordrow/constants.go
@@ -1,0 +1,8 @@
+package main
+
+// The non-zero exit codes used by wordrow.
+const (
+	missingArgumentExitCode = iota + 1
+	runtimeErrorExitCode
+	runtimeWarningExitCode
+)


### PR DESCRIPTION
Closes #129

The program will now exit with non-zero exit codes for errors (problems that prevent *wordrow* from doing its job) and warnings (problems that only limit *wordrow*, those are considered errors in --strict mode).

This required some refactoring of `main.go`. The run function now return a list of errors and warnings (following the above distinction). A new function in `main.go` now sets the exit code based on these two slices.