### PR TITLE
Set-up Workflow to automatically create Release from tags

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,7 @@ name: Fuzz
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   fuzz:
@@ -11,16 +11,17 @@ jobs:
     env:
       FUZZIT_API_KEY: ${{ secrets.FUZZIT_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up Go 1.13
       uses: actions/setup-go@v2
       with:
         go-version: 1.13
-    - name: Get Fuzzit-CLI
+    - name: Install the Fuzzit CLI
       run: |
         wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
         chmod a+x fuzzit
-    - name: Get go-fuzz-build
+    - name: Install go-fuzz-build
       run: go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
     - name: Rename package main
       run: sed -i "s|package main|package _main|g" ./cmd/wordrow/*.go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,6 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-
-    # Setup
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Set up Go 1.13
@@ -36,11 +34,9 @@ jobs:
         ./cc-test-reporter upload-coverage -i ./coverage.cc -r ${{ secrets.CODECLIMATE_REPORTER_ID }}
 
   lint:
-    name: Lint
+    name: Lint & Analysis
     runs-on: ubuntu-latest
     steps:
-
-    # Setup
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Set up NodeJS  # NodeJS required for MarkDown linting

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: wordrow CI
 on:
-  - push
-  - pull_request
+- push
+- pull_request
 
 jobs:
   build:
@@ -10,18 +10,14 @@ jobs:
     steps:
 
     # Setup
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up Go 1.13
       uses: actions/setup-go@v2
       with:
         go-version: 1.13
-    - uses: actions/checkout@v2
     - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      run: go get -v -t -d ./...
 
     # Building
     - name: Build
@@ -45,15 +41,16 @@ jobs:
     steps:
 
     # Setup
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.13
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up NodeJS  # NodeJS required for MarkDown linting
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - uses: actions/checkout@v2
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.13
     - name: Get dependencies
       run: make install-dev-deps
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-
-    # Setup
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Set up Go 1.13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+
+    # Setup
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.13
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    # Verify release validity
+    - name: Build
+      run: make build
+    - name: Test
+      run: make test
+
+    # Create release
+    - name: Get release version
+      id: tag_version
+      uses: dawidd6/action-get-tag@v1
+    - name: Get release text
+      id: tag_text
+      uses: ericcornelissen/git-tag-annotation-action@v1
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ steps.tag_version.outputs.tag }}
+        body: ${{ steps.tag_text.outputs.git-tag-annotation }}
+        draft: false
+        prerelease: true
+
+    # Upload release assets
+    - name: Build assets
+      run: make build-all
+    - name: Upload linux-amd64 Binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./wordrow_linux-amd64.o
+        asset_name: wordrow_linux-amd64.o
+        asset_content_type: application/exe
+    - name: Upload win-amd64 Binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./wordrow_win-amd64.exe
+        asset_name: wordrow_win-amd64.exe
+        asset_content_type: application/exe

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,11 +2,11 @@ name: Security
 on:
   pull_request:
     branches:
-      - master
+    - master
   push:
     branches:
-      - master
-      - 'sec**'
+    - master
+    - 'sec**'
 
 jobs:
   codeql:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
-    - run: git checkout HEAD^2
+    - name: Checkout latest commit in Pull Request
+      run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
     - name: Initialize CodeQL
@@ -25,14 +26,15 @@ jobs:
       with:
         languages: go
         queries: security-extended
-    - name: Perform CodeQL Analysis
+    - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v1
 
   fuzz:
     name: Fuzz (build only)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up Go 1.13
       uses: actions/setup-go@v2
       with:
@@ -52,8 +54,9 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-    - uses: actions/checkout@v2
-    - name: Run gosec Security Scanner
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Run gosec security scanner
       uses: securego/gosec@master
       with:
         args: -conf .gosecrc.json ./...
@@ -64,7 +67,8 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up NodeJS  # NodeJS required for snyk-CLI
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Add a new GitHub Actions Workflow that will create Releases based on git tags. Whenever a git tag is pushed starting with a "v", this Workflow will create a new GitHub Release for it. The release message will be taken from the git tag annotation, and release assets are automatically generated and uploaded.

To make this possible we use [actions/create-release-at-v1](https://github.com/actions/create-release) to create the GitHub release, [actions/upload-release-asset-at-v1](https://github.com/actions/upload-release-asset) to upload the release assets, [dawidd6/action-get-tag-at-v1](https://github.com/kceb/git-message-action) to (easily) get the tag name from the environment, and [ericcornelissen/git-tag-annotation-action-at-v1](https://github.com/ericcornelissen/git-tag-annotation-action) to (easily) get the annotation message.

As described in the "Known issues" section of the README of ericcornelissen/git-tag-annotation-action-at-v1, this Workflow uses actions/checkout-at-v1 instead of v2 due to incompatibility.
